### PR TITLE
Update deprecated privilege escalation method

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 
 - name: Configure ~/.{{ aliases_shell }}_aliases
-  sudo: yes
-  sudo_user: "{{ aliases_user }}"
+  become: yes
+  become_user: "{{ aliases_user }}"
   lineinfile: >
     dest=~/.{{ aliases_shell }}_aliases
     line="{{ item }}"


### PR DESCRIPTION
Update deprecated privilege escalation method sudo in favor of ansible become. According to documentation as of 1.9 become supersedes the old sudo/su.