### PR TITLE
fix conditional os family check error

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,4 +24,4 @@
     line="if [ -f ~/.bash_aliases ]; then\n . ~/.bash_aliases\n fi"
     state=present
     backup=yes
-  when: ansible_facts[‘os_family’] == "RedHat"
+  when: ansible_facts['os_family'] == "RedHat"


### PR DESCRIPTION
The error is caused by the use of invalid single quotation characters instead of apostrophes